### PR TITLE
chore: add build pipeline

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -1,0 +1,291 @@
+name: $(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
+ 
+trigger:
+  branches:
+    include:
+    - main
+  tags:
+    include:
+    - 'v*'
+ 
+pr: none
+ 
+variables:
+  buildConfiguration: 'Release'
+  buildPlatform: 'Any CPU'
+ 
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+ 
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      vmImage: windows-latest
+    stages:
+    - stage: Build .NET
+      jobs:
+        - job: build
+          templateContext:
+            outputs:
+              - output: pipelineArtifact
+                displayName: 'Build the Microsoft.Agents.M365Copilot* package artifacts'
+                artifactName: ArtifactsForRelease
+                targetPath: $(Build.ArtifactStagingDirectory)
+          steps:
+          - task: UseDotNet@2
+            displayName: 'Use .NET 8'
+            inputs:
+              version: 8.x
+          - task: UseDotNet@2
+            displayName: 'Use .NET 6 (for code signing tasks)'
+            inputs:
+              packageType: sdk
+              version: 6.x
+ 
+         # Install the nuget tool.
+          - task: NuGetToolInstaller@1
+            displayName: 'Install Nuget dependency manager'
+            inputs:
+              versionSpec: '>=5.2.0'
+              checkLatest: true
+          
+          # Build the Product project
+          - task: DotNetCoreCLI@2
+            displayName: 'Build M365 CoPilot Agents SDK'
+            inputs:
+              projects: '$(Build.SourcesDirectory)\dotnet\Microsoft.Agents.M365Copilot.sln'
+              arguments: '--configuration $(BuildConfiguration) --no-incremental'
+          
+          # Run the Unit test
+          - task: DotNetCoreCLI@2
+            displayName: 'Test M365 CoPilot Agents SDK
+            inputs:
+              command: test
+              projects: '$(Build.SourcesDirectory)\dotnet\Microsoft.Agents.M365Copilot.sln'
+              arguments: '--configuration $(BuildConfiguration) --no-build -f net8.0'
+
+          - task: EsrpCodeSigning@5
+            displayName: 'ESRP DLL Strong Name'
+            inputs:
+              ConnectedServiceName: 'Federated DevX ESRP Managed Identity Connection'
+              AppRegistrationClientId: '65035b7f-7357-4f29-bf25-c5ee5c3949f8'
+              AppRegistrationTenantId: 'cdc5aeea-15c5-4db6-b079-fcadd2505dc2'
+              AuthAKVName: 'akv-prod-eastus'
+              AuthCertName: 'ReferenceLibraryPrivateCert'
+              AuthSignCertName: 'ReferencePackagePublisherCertificate'
+              FolderPath: src  # This path should already omit test dlls as they exist in the `tests` folder
+              Pattern: '**\Microsoft.Agents.M365Copilot.*.dll'
+              signConfigType: inlineSignParams
+              UseMinimatch: true
+              inlineOperation: |
+                [
+                    {
+                        "keyCode": "CP-233863-SN",
+                        "operationSetCode": "StrongNameSign",
+                        "parameters": [],
+                        "toolName": "sign",
+                        "toolVersion": "1.0"
+                    },
+                    {
+                        "keyCode": "CP-233863-SN",
+                        "operationSetCode": "StrongNameVerify",
+                        "parameters": [],
+                        "toolName": "sign",
+                        "toolVersion": "1.0"
+                    }
+                ]
+              SessionTimeout: 20
+              MaxConcurrency: 50
+              MaxRetryAttempts: 5
+              PendingAnalysisWaitTimeoutMinutes: 5
+
+          # Sign the ESRP Code Signing for Microsoft.Agents.M365Copilot.Core DLL
+          - task: EsrpCodeSigning@5
+            displayName: 'ESRP Code Signing for Microsoft.Agents.M365Copilot.Core DLL'
+            inputs:
+              ConnectedServiceName: 'Federated DevX ESRP Managed Identity Connection'
+              AppRegistrationClientId: '65035b7f-7357-4f29-bf25-c5ee5c3949f8'
+              AppRegistrationTenantId: 'cdc5aeea-15c5-4db6-b079-fcadd2505dc2'
+              AuthAKVName: 'akv-prod-eastus'
+              AuthCertName: 'ReferenceLibraryPrivateCert'
+              AuthSignCertName: 'ReferencePackagePublisherCertificate'
+              FolderPath: "$(Build.SourcesDirectory)/dotnet/src/Microsoft.Agents.M365Copilot.Core/bin/$(BuildConfiguration)/"
+              Pattern: "*Core.dll"
+              UseMinimatch: false
+              signConfigType: 'inlineSignParams'
+              inlineOperation: |
+                [
+                    {
+                        "keyCode": "CP-230012",
+                        "operationSetCode": "SigntoolSign",
+                        "parameters": [
+                        {
+                            "parameterName": "OpusName",
+                            "parameterValue": "Microsoft"
+                        },
+                        {
+                            "parameterName": "OpusInfo",
+                            "parameterValue": "http://www.microsoft.com"
+                        },
+                        {
+                            "parameterName": "FileDigest",
+                            "parameterValue": "/fd \"SHA256\""
+                        },
+                        {
+                            "parameterName": "PageHash",
+                            "parameterValue": "/NPH"
+                        },
+                        {
+                            "parameterName": "TimeStamp",
+                            "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                        }
+                        ],
+                        "toolName": "sign",
+                        "toolVersion": "1.0"
+                    },
+                    {
+                        "keyCode": "CP-230012",
+                        "operationSetCode": "SigntoolVerify",
+                        "parameters": [ ],
+                        "toolName": "sign",
+                        "toolVersion": "1.0"
+                    }
+                ]
+              SessionTimeout: '20'
+              MaxConcurrency: '50'
+              MaxRetryAttempts: '5'
+              PendingAnalysisWaitTimeoutMinutes: '5'
+
+          # Sign the ESRP Code Signing for Microsoft.Agents.M365Copilot.Beta DLL
+          - task: EsrpCodeSigning@5
+            displayName: 'ESRP Code Signing for Microsoft.Agents.M365Copilot.Beta DLL'
+            inputs:
+              ConnectedServiceName: 'Federated DevX ESRP Managed Identity Connection'
+              AppRegistrationClientId: '65035b7f-7357-4f29-bf25-c5ee5c3949f8'
+              AppRegistrationTenantId: 'cdc5aeea-15c5-4db6-b079-fcadd2505dc2'
+              AuthAKVName: 'akv-prod-eastus'
+              AuthCertName: 'ReferenceLibraryPrivateCert'
+              AuthSignCertName: 'ReferencePackagePublisherCertificate'
+              FolderPath: "$(Build.SourcesDirectory)/dotnet/src/Microsoft.Agents.M365Copilot.Beta/bin/$(BuildConfiguration)/"
+              Pattern: "*Beta.dll"
+              UseMinimatch: false
+              signConfigType: 'inlineSignParams'
+              inlineOperation: |
+                [
+                    {
+                        "keyCode": "CP-230012",
+                        "operationSetCode": "SigntoolSign",
+                        "parameters": [
+                        {
+                            "parameterName": "OpusName",
+                            "parameterValue": "Microsoft"
+                        },
+                        {
+                            "parameterName": "OpusInfo",
+                            "parameterValue": "http://www.microsoft.com"
+                        },
+                        {
+                            "parameterName": "FileDigest",
+                            "parameterValue": "/fd \"SHA256\""
+                        },
+                        {
+                            "parameterName": "PageHash",
+                            "parameterValue": "/NPH"
+                        },
+                        {
+                            "parameterName": "TimeStamp",
+                            "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                        }
+                        ],
+                        "toolName": "sign",
+                        "toolVersion": "1.0"
+                    },
+                    {
+                        "keyCode": "CP-230012",
+                        "operationSetCode": "SigntoolVerify",
+                        "parameters": [ ],
+                        "toolName": "sign",
+                        "toolVersion": "1.0"
+                    }
+                ]
+              SessionTimeout: '20'
+              MaxConcurrency: '50'
+              MaxRetryAttempts: '5'
+              PendingAnalysisWaitTimeoutMinutes: '5'
+ 
+
+
+          # arguments are not parsed in DotNetCoreCLI@2 task for `pack` command, that's why we have a custom pack command here
+          - pwsh: dotnet pack $env:BUILD_SOURCESDIRECTORY/dotnet/src/Microsoft.Agents.M365Copilot.Core/Microsoft.Agents.M365Copilot.Core.csproj /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg --no-build --output $env:BUILD_ARTIFACTSTAGINGDIRECTORY --configuration $env:BUILD_CONFIGURATION
+            env:
+              BUILD_CONFIGURATION: $(BuildConfiguration)
+            displayName: Dotnet pack
+
+          - pwsh: dotnet pack $env:BUILD_SOURCESDIRECTORY/dotnet/src/Microsoft.Agents.M365Copilot.Beta/Microsoft.Agents.M365Copilot.Beta.csproj /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg --no-build --output $env:BUILD_ARTIFACTSTAGINGDIRECTORY --configuration $env:BUILD_CONFIGURATION
+            env:
+              BUILD_CONFIGURATION: $(BuildConfiguration)
+            displayName: Dotnet pack
+
+          # - task: PowerShell@2
+          #   displayName: 'Validate project version has been incremented'
+          #   condition: and(contains(variables['build.sourceBranch'], 'refs/tags/v'), succeeded())
+          #   inputs:
+          #     targetType: 'filePath'
+          #     filePath: $(System.DefaultWorkingDirectory)\scripts\ValidateProjectVersionUpdated.ps1
+          #     arguments: '-projectPath "$(Build.SourcesDirectory)/Directory.Build.props" -packageName "Microsoft.DeclarativeAgents.Manifest"'
+          #     pwsh: true
+          
+          - task: EsrpCodeSigning@5
+            displayName: 'ESRP Code Signing for Core and Beta NuGet packages'
+          
+            inputs:
+              ConnectedServiceName: 'Federated DevX ESRP Managed Identity Connection'
+              AppRegistrationClientId: '65035b7f-7357-4f29-bf25-c5ee5c3949f8'
+              AppRegistrationTenantId: 'cdc5aeea-15c5-4db6-b079-fcadd2505dc2'
+              AuthAKVName: 'akv-prod-eastus'
+              AuthCertName: 'ReferenceLibraryPrivateCert'
+              AuthSignCertName: 'ReferencePackagePublisherCertificate'
+              FolderPath: '$(Build.ArtifactStagingDirectory)'
+              Pattern: '*.nupkg'
+              signConfigType: 'inlineSignParams'
+              inlineOperation: |
+                [
+                                    {
+                                        "keyCode": "CP-401405",
+                                        "operationSetCode": "NuGetSign",
+                                        "parameters": [ ],
+                                        "toolName": "sign",
+                                        "toolVersion": "1.0"
+                                    },
+                                    {
+                                        "keyCode": "CP-401405",
+                                        "operationSetCode": "NuGetVerify",
+                                        "parameters": [ ],
+                                        "toolName": "sign",
+                                        "toolVersion": "1.0"
+                                    }
+                                ]
+              SessionTimeout: '60'
+              MaxConcurrency: '50'
+              MaxRetryAttempts: '5'
+              PendingAnalysisWaitTimeoutMinutes: '5'
+ 
+          # - task: CopyFiles@2
+          #   displayName: 'Copy release scripts to artifact staging directory'
+          #   condition: and(contains(variables['build.sourceBranch'], 'refs/tags/v'), succeeded())
+          #   inputs:
+          #     SourceFolder: '$(Build.SourcesDirectory)'
+          #     Contents: 'scripts\**'
+          #     TargetFolder: '$(Build.ArtifactStagingDirectory)'
+ 
+          - task: 1ES.PublishPipelineArtifact@1
+            displayName: 'Stage Artifacts: Nugets'
+            inputs:
+              artifactName: NuGets
+              targetPath: $(Build.ArtifactStagingDirectory)


### PR DESCRIPTION
This is premature PR as StartRight doesn't allow defining a pipeline with a file in anything other than the default branch. Once merged, I can create the pipeline with the main branch and then change the pipeline to target this addbuildpipeline branch for validation.