### PR TITLE
fix: beta client initialization

### DIFF
--- a/dotnet/src/Microsoft.Agents.M365Copilot.Beta/AgentsM365CopilotBetaServiceClient.cs
+++ b/dotnet/src/Microsoft.Agents.M365Copilot.Beta/AgentsM365CopilotBetaServiceClient.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Agents.M365Copilot.Beta
         public AgentsM365CopilotBetaServiceClient(
             IAuthenticationProvider authenticationProvider,
             string baseUrl = null
-            ) : this(new BaseRequestAdapter(authenticationProvider, copilotClientOptions), baseUrl)
+            ) : this(CopilotClientFactory.Create(copilotClientOptions, version: "beta"), authenticationProvider, baseUrl)
         {
         }
 


### PR DESCRIPTION
Ensure that when creating a AgentsM365CopilotBetaServiceClient with only an IAuthenticationProvider that the baseUrl on the http client points at the beta version

Fixes: #78 