### PR TITLE
chore: update and publish beta package with reference to core package

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-    "dotnet/src/Microsoft.Agents.M365Copilot.Beta": "1.0.0-preview.3",
+    "dotnet/src/Microsoft.Agents.M365Copilot.Beta": "1.0.0-preview.4",
     "dotnet/src/Microsoft.Agents.M365Copilot.Core": "1.0.0-preview.3",
     "typescript/packages/agents-m365copilot-beta": "1.0.0-preview.3",
     "typescript/packages/agents-m365copilot-core": "1.0.0-preview.1",

--- a/typescript/packages/agents-m365copilot-beta/CHANGELOG.md
+++ b/typescript/packages/agents-m365copilot-beta/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.0-preview.4](https://github.com/microsoft/Agents-M365Copilot/compare/@microsoft/agents-m365copilot-beta-v1.0.0-preview.3...@microsoft/agents-m365copilot-beta-v1.0.0-preview.4) (2025-07-16)
+
+### Bug Fixes
+
+* fix dependency to point at agents-m365copilot-core package instead of file reference 
+
 ## [1.0.0-preview.3](https://github.com/microsoft/Agents-M365Copilot/compare/@microsoft/agents-m365copilot-beta-v1.0.0-preview.2...@microsoft/agents-m365copilot-beta-v1.0.0-preview.3) (2025-07-15)
 
 

--- a/typescript/packages/agents-m365copilot-beta/package.json
+++ b/typescript/packages/agents-m365copilot-beta/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/agents-m365copilot-beta",
-	"version": "1.0.0-preview.3",
+	"version": "1.0.0-preview.4",
 	"description": "Microsoft Copilot client library",
 	"keywords": [
 		"microsoft",


### PR DESCRIPTION
We published beta with a reference to the core package as a file reference instead of package reference. 

Do not merge -- likely to close without merging due to generation.