### PR TITLE
Fixing entrypoint to point towards index.ts instead

### DIFF
--- a/typescript/packages/agents-m365copilot-beta/build.js
+++ b/typescript/packages/agents-m365copilot-beta/build.js
@@ -3,7 +3,7 @@ import esbuild from "esbuild";
 // Node specific bundle
 esbuild
 	.build({
-		entryPoints: ["./generated/baseAgentsM365CopilotBetaServiceClient.ts"], // Adjust to the main entry file of the package
+		entryPoints: ["./index.ts"], // Adjust to the main entry file of the package
 		bundle: true,
 		outfile: "./dist/index.node.js",
 		platform: "node",
@@ -16,7 +16,7 @@ esbuild
 // Browser specific bundle
 esbuild
 	.build({
-		entryPoints: ["./generated/baseAgentsM365CopilotBetaServiceClient.ts"], // Adjust to the main entry file of the package
+		entryPoints: ["./index.ts"], // Adjust to the main entry file of the package
 		bundle: true,
 		outfile: "./dist/index.browser.js",
 		platform: "browser",


### PR DESCRIPTION
Prior entrypoint was not letting the beta package to export all the generated modules only base agent. This should fix the issue