### PR TITLE
Removing redundant conditionals in the build step

### DIFF
--- a/.azure-pipelines/cd-build-deploy-typescript-beta.yml
+++ b/.azure-pipelines/cd-build-deploy-typescript-beta.yml
@@ -61,13 +61,11 @@ extends:
             - script: npm run build --workspace=$(package_dir_beta)
               displayName: 'Build $(package_name_beta)'
               workingDirectory: '$(Build.SourcesDirectory)/typescript/'
-              condition: or(startsWith(variables['Build.SourceBranch'], '@microsoft/agents-m365copilot-beta'), eq(variables['Build.Reason'], 'Manual'))
 
             - script: npm pack --workspace=$(package_dir_beta) --pack-destination=$(Build.SourcesDirectory)/typescript/$(package_dir_beta)
               displayName: 'Generate npm package $(package_name_beta)'
               workingDirectory: '$(Build.SourcesDirectory)/typescript'
-              condition: or(startsWith(variables['Build.SourceBranch'], '@microsoft/agents-m365copilot-beta'), eq(variables['Build.Reason'], 'Manual'))
-
+              
             # Stage artifacts for Beta package
 
             - task: CopyFiles@2
@@ -77,8 +75,7 @@ extends:
                 Contents: |
                   microsoft-agents-m365copilot-beta*.tgz
               displayName: "Copy npm package files for $(package_name_beta)"
-              condition: or(startsWith(variables['Build.SourceBranch'], '@microsoft/agents-m365copilot-beta'), eq(variables['Build.Reason'], 'Manual'))
-
+              
           templateContext:
             outputs:
               - output: pipelineArtifact


### PR DESCRIPTION
Removing conditionals that were already applied at the start of the build stage. They were causing the build steps to be skipped because of the `startWith` conditional. Causing the following conditional to return false:

```
2025-08-05T20:40:27.5188404Z Skipping step due to condition evaluation.
Evaluating: or(startsWith(variables['Build.SourceBranch'], '@microsoft/agents-m365copilot-beta'), eq(variables['Build.Reason'], 'Manual'))
Expanded: or(startsWith('refs/tags/@microsoft/agents-m365copilot-beta-v1.0.0-preview.5', '@microsoft/agents-m365copilot-beta'), eq('IndividualCI', 'Manual'))
Result: False
```
