### PR TITLE
fix: adding do not ignore rule

### DIFF
--- a/dotnet/.gitignore
+++ b/dotnet/.gitignore
@@ -200,6 +200,8 @@ PublishScripts/
 *.snupkg
 # The packages folder can be ignored because of Package Restore
 **/[Pp]ackages/*
+# But don't ignore Packages folders inside Generated folders
+!**/Generated/**/**/Packages/*
 # except build/, which is used as an MSBuild target.
 !**/[Pp]ackages/build/
 # Uncomment if necessary however generally it will be regenerated when needed


### PR DESCRIPTION
New generated beta code has a folder called Packages that was being ignored by dotnet's gitignore. This rule will let us commit the new generated folder:
<img width="311" height="144" alt="image" src="https://github.com/user-attachments/assets/f45a9768-cf0a-4f0e-bdcc-031de251ec1f" />
