### PR TITLE
chore(ci): specify package spec to only target nupkg

### DIFF
--- a/.azure-pipelines/cd-build-deploy-dotnet-beta.yml
+++ b/.azure-pipelines/cd-build-deploy-dotnet-beta.yml
@@ -157,7 +157,7 @@ extends:
                   inputs:
                     useDotNetTask: false
                     packageParentPath: $(nugetArtifacts)
-                    packagesToPush: '!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg;$(nugetArtifacts)/**/*nupkg'
+                    packagesToPush: '!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg;$(nugetArtifacts)/**/*.nupkg'
                     nuGetFeedType: external  # Change to external for external
                     publishPackageMetadata: true
                     publishFeedCredentials: 'M365 Copilot NuGet Connection'

--- a/.azure-pipelines/cd-build-deploy-dotnet-core.yml
+++ b/.azure-pipelines/cd-build-deploy-dotnet-core.yml
@@ -158,7 +158,7 @@ extends:
                   inputs:
                     useDotNetTask: false
                     packageParentPath: $(nugetArtifacts)
-                    packagesToPush: '!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg;$(nugetArtifacts)/**/*nupkg'
+                    packagesToPush: '!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg;$(nugetArtifacts)/**/*.nupkg'
                     nuGetFeedType: external  # Change to external for external
                     publishPackageMetadata: true
                     publishFeedCredentials: 'M365 Copilot NuGet Connection'

--- a/.azure-pipelines/cd-build-deploy-dotnet-v1.yml
+++ b/.azure-pipelines/cd-build-deploy-dotnet-v1.yml
@@ -153,7 +153,7 @@ extends:
                   inputs:
                     useDotNetTask: false
                     packageParentPath: $(nugetArtifacts)
-                    packagesToPush: '!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg;$(nugetArtifacts)/**/*nupkg'
+                    packagesToPush: '!$(Build.ArtifactStagingDirectory)/**/*.symbols.nupkg;$(nugetArtifacts)/**/*.nupkg'
                     nuGetFeedType: external  # Change to external for external
                     publishPackageMetadata: true
                     publishFeedCredentials: 'M365 Copilot NuGet Connection'


### PR DESCRIPTION
This should remove the error on nuget publication where the snupkg is attempted to be pushed twice. It should just clean up the ADO Pipeline results