### PR TITLE
Fix: removing .net8 requirement on the beta pipeline

### DIFF
--- a/.azure-pipelines/cd-build-deploy-dotnet-beta.yml
+++ b/.azure-pipelines/cd-build-deploy-dotnet-beta.yml
@@ -96,7 +96,7 @@ extends:
               inputs:
                 command: test
                 projects: '$(Build.SourcesDirectory)/dotnet/tests/Microsoft.Agents.M365Copilot.Beta.Tests/Microsoft.Agents.M365Copilot.Beta.Tests.csproj'
-                arguments: '--configuration $(buildConfiguration) -f net8.0'
+                arguments: '--configuration $(buildConfiguration)'
 
             # Strong name for Beta using ESRP
             - template: .azure-pipelines/templates/esrp-strongname.yml@self


### PR DESCRIPTION
Removing .net8 requirement that was causing issues when running the release beta pipeline. This should enable the release of the newest version