### PR TITLE
Update .NET SDK and fix dependency vulnerabilities

### DIFF
--- a/dotnet/Directory.Packages.props
+++ b/dotnet/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Azure.Identity" Version="1.13.2" />
@@ -9,6 +10,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.6.1" />
     <PackageVersion Include="Microsoft.IdentityModel.Validators" Version="8.6.1" />
+    <PackageVersion Include="Microsoft.Bcl.Memory" Version="9.0.14" />
     <PackageVersion Include="Microsoft.Kiota.Bundle" Version="1.17.4" />
     <PackageVersion Include="Microsoft.Kiota.Authentication.Azure" Version="1.17.4" />
     <PackageVersion Include="Microsoft.Agents.M365Copilot" Version="0.1.0-preview.1" />

--- a/dotnet/nuget.config
+++ b/dotnet/nuget.config
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/dotnet/src/Microsoft.Agents.M365Copilot.Core/global.json
+++ b/dotnet/src/Microsoft.Agents.M365Copilot.Core/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.417", /* https://github.com/dotnet/maui/wiki/.NET-7-and-.NET-MAUI */
+    "version": "10.0.201", /* https://github.com/dotnet/maui/wiki/.NET-7-and-.NET-MAUI */
     "rollForward": "major"
   }
 }

--- a/dotnet/src/Microsoft.Agents.M365Copilot.Sample/Microsoft.Agents.M365Copilot.Sample.csproj
+++ b/dotnet/src/Microsoft.Agents.M365Copilot.Sample/Microsoft.Agents.M365Copilot.Sample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <NoWarn>1591</NoWarn> <!-- Suppress warnings for missing XML comments -->

--- a/dotnet/tests/Microsoft.Agents.M365Copilot.Beta.Tests/Microsoft.Agents.M365Copilot.Beta.Tests.csproj
+++ b/dotnet/tests/Microsoft.Agents.M365Copilot.Beta.Tests/Microsoft.Agents.M365Copilot.Beta.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
Closes #315

## Summary

- Update .NET SDK from 6.0.417 to 10.0.201 in global.json
- Fix NU1507 warnings by adding nuget.config with package source mapping
- Fix CVE-2026-26127 (high severity) in transitive dependency Microsoft.Bcl.Memory by pinning to 9.0.14
- Enable CentralPackageTransitivePinningEnabled for transitive dependency version control
- Align test and sample project target frameworks to include net10.0

## Warnings Resolved

| Warning | Description |
|---------|-------------|
| NU1507 | Multiple package sources without source mapping |
| NU1903 | Microsoft.Bcl.Memory 9.0.0 high severity vulnerability (CVE-2026-26127) |

## Verification

- All 142 tests pass on net8.0 and net10.0
- Build succeeds with no errors
