### PR TITLE
chore(deps)!: update Microsoft.Kiota dependencies to v2

### DIFF
--- a/dotnet/src/Microsoft.Agents.M365Copilot.Core/Microsoft.Agents.M365Copilot.Core.csproj
+++ b/dotnet/src/Microsoft.Agents.M365Copilot.Core/Microsoft.Agents.M365Copilot.Core.csproj
@@ -18,6 +18,7 @@
     <RepositoryUrl>https://github.com/microsoft/Agents-M365Copilot/dotnet</RepositoryUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <!-- Since deps live in Directory.Packages.props changes won't result in automatic version updates -->
     <!-- x-release-please-start-version -->
     <Version>1.1.0</Version>
     <!-- x-release-please-end -->


### PR DESCRIPTION
BREAKING CHANGE: Microsoft.Kiota* packages updated to version 2

This is actually a non-breaking change since the external API surface changed.

BEGIN_COMMIT_OVERRIDE
chore(deps): upgrade for Kiota dependencies to v2
END_COMMIT_OVERRIDE