### PR TITLE
Fix TS CI: include v1 package in lerna build/test scope

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -33,10 +33,10 @@
 	],
 	"scripts": {
 		"build": "npm run prettier:check && npm run clean && npm run build:all",
-		"build:all": "lerna run build --scope @microsoft/agents-m365copilot-*",
+		"build:all": "lerna run build --scope @microsoft/agents-m365copilot*",
 		"build:beta": "npm run build --prefix packages/agents-m365copilot-core && npm run build --prefix packages/agents-m365copilot-beta",
-		"clean": "lerna run --parallel --stream --scope @microsoft/agents-m365copilot-* clean",
-		"test": "lerna run --scope @microsoft/agents-m365copilot-* test",
+		"clean": "lerna run --parallel --stream --scope @microsoft/agents-m365copilot* clean",
+		"test": "lerna run --scope @microsoft/agents-m365copilot* test",
 		"test:coverage": "lerna run test:coverage",
 		"tsc:version": "tsc --version",
 		"prettier:base": "prettier --parser typescript",


### PR DESCRIPTION
## What
The TypeScript root `package.json` scripts `build:all`, `clean`, and `test` used:

`--scope @microsoft/agents-m365copilot-*`

The trailing hyphen makes the glob match `@microsoft/agents-m365copilot-beta` and `@microsoft/agents-m365copilot-core` but **not** the bare v1 package `@microsoft/agents-m365copilot`. As a result the **v1 TypeScript package is never compiled or tested in CI** — its green check is a false pass.

## Fix
Drop the hyphen so the glob matches all three packages:

`--scope @microsoft/agents-m365copilot*`
