### PR TITLE
Route package restore through the CFS central package feed

### DIFF
--- a/.azure-pipelines/cd-build-deploy-dotnet-beta.yml
+++ b/.azure-pipelines/cd-build-deploy-dotnet-beta.yml
@@ -58,6 +58,21 @@ extends:
                 versionSpec: '>=6.0.0'
                 checkLatest: true
             
+            - task: NuGetAuthenticate@1
+              displayName: 'Authenticate to Azure Artifacts'
+
+            - pwsh: |
+                @"
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                  <packageSources>
+                    <clear />
+                    <add key="GraphDeveloperExperiences_Public" value="https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/nuget/v3/index.json" />
+                  </packageSources>
+                </configuration>
+                "@ | Set-Content -Path "$(Build.SourcesDirectory)/nuget.config" -Encoding UTF8
+              displayName: 'Create nuget.config (central feed)'
+
             # Enable signing for the .NET projects
             - pwsh: |
                 # This allows us to not have to checkin .csproj or Directory.Build.props files with DelaySign and 

--- a/.azure-pipelines/cd-build-deploy-dotnet-core.yml
+++ b/.azure-pipelines/cd-build-deploy-dotnet-core.yml
@@ -58,6 +58,21 @@ extends:
                 versionSpec: '>=6.0.0'
                 checkLatest: true
             
+            - task: NuGetAuthenticate@1
+              displayName: 'Authenticate to Azure Artifacts'
+
+            - pwsh: |
+                @"
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                  <packageSources>
+                    <clear />
+                    <add key="GraphDeveloperExperiences_Public" value="https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/nuget/v3/index.json" />
+                  </packageSources>
+                </configuration>
+                "@ | Set-Content -Path "$(Build.SourcesDirectory)/nuget.config" -Encoding UTF8
+              displayName: 'Create nuget.config (central feed)'
+
             # Enable signing for the .NET projects
             - pwsh: |
                 # This allows us to not have to checkin .csproj or Directory.Build.props files with DelaySign and 

--- a/.azure-pipelines/cd-build-deploy-dotnet-v1.yml
+++ b/.azure-pipelines/cd-build-deploy-dotnet-v1.yml
@@ -61,6 +61,21 @@ extends:
                 versionSpec: '>=6.0.0'
                 checkLatest: true
             
+            - task: NuGetAuthenticate@1
+              displayName: 'Authenticate to Azure Artifacts'
+
+            - pwsh: |
+                @"
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                  <packageSources>
+                    <clear />
+                    <add key="GraphDeveloperExperiences_Public" value="https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/nuget/v3/index.json" />
+                  </packageSources>
+                </configuration>
+                "@ | Set-Content -Path "$(Build.SourcesDirectory)/nuget.config" -Encoding UTF8
+              displayName: 'Create nuget.config (central feed)'
+
             # Enable signing for the .NET projects
             - pwsh: |
                 # This allows us to not have to checkin .csproj or Directory.Build.props files with DelaySign and 

--- a/.azure-pipelines/cd-build-deploy-python-beta.yml
+++ b/.azure-pipelines/cd-build-deploy-python-beta.yml
@@ -49,6 +49,12 @@ extends:
                 versionSpec: '3.x'
                 addToPath: true
 
+            - task: PipAuthenticate@1
+              displayName: 'Authenticate pip to Azure Artifacts'
+              inputs:
+                artifactFeeds: '$(System.TeamProject)/GraphDeveloperExperiences_Public'
+                onlyAddExtraIndex: false
+
             - script: python -m pip install --upgrade pip
 
             # Build, test, and package Beta Python library
@@ -57,6 +63,15 @@ extends:
               workingDirectory: '$(Build.SourcesDirectory)/python/$(library_dir_beta)'
               # This condition allows the build to run for both tagged beta builds or manual builds.
               condition: or(contains(variables['Build.SourceBranch'], 'microsoft_agents_m365copilot_beta'), eq(variables['Build.Reason'], 'Manual'))
+
+            - script: |
+                poetry source add --priority=primary azure-feed "https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/pypi/simple/"
+                poetry config http-basic.azure-feed "azure" "$SYSTEM_ACCESSTOKEN"
+              displayName: 'Configure Poetry to use Azure Artifacts feed'
+              workingDirectory: '$(Build.SourcesDirectory)/python/$(library_dir_beta)'
+              condition: or(contains(variables['Build.SourceBranch'], 'microsoft_agents_m365copilot_beta'), eq(variables['Build.Reason'], 'Manual'))
+              env:
+                SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
             - script: poetry install
               displayName: 'Install beta dependencies'

--- a/.azure-pipelines/cd-build-deploy-python-v1.yml
+++ b/.azure-pipelines/cd-build-deploy-python-v1.yml
@@ -65,12 +65,26 @@ extends:
                 versionSpec: '3.x'
                 addToPath: true
 
+            - task: PipAuthenticate@1
+              displayName: 'Authenticate pip to Azure Artifacts'
+              inputs:
+                artifactFeeds: '$(System.TeamProject)/GraphDeveloperExperiences_Public'
+                onlyAddExtraIndex: false
+
             - script: python -m pip install --upgrade pip
 
             # Build, test, and package V1 Python library
             - script: pip install poetry
               displayName: 'Install Poetry'
               workingDirectory: '$(Build.SourcesDirectory)/python/$(library_dir_v1)'
+
+            - script: |
+                poetry source add --priority=primary azure-feed "https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/pypi/simple/"
+                poetry config http-basic.azure-feed "azure" "$SYSTEM_ACCESSTOKEN"
+              displayName: 'Configure Poetry to use Azure Artifacts feed'
+              workingDirectory: '$(Build.SourcesDirectory)/python/$(library_dir_v1)'
+              env:
+                SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
             - script: poetry install
               displayName: 'Install v1 dependencies'

--- a/.azure-pipelines/cd-build-deploy-typescript-beta.yml
+++ b/.azure-pipelines/cd-build-deploy-typescript-beta.yml
@@ -47,9 +47,13 @@ extends:
               displayName: 'Install Node.js'
               inputs:
                 version: '22.x'
-            - script: npm ci
+            - task: Npm@1
               displayName: 'Install npm dependencies'
-              workingDirectory: '$(Build.SourcesDirectory)/typescript/'
+              inputs:
+                command: 'ci'
+                workingDir: '$(Build.SourcesDirectory)/typescript'
+                customRegistry: 'useFeed'
+                customFeed: 'Graph Developer Experiences/GraphDeveloperExperiences_Public'
 
             # Build Beta TypeScript package
             - script: npm run build --workspace=$(package_dir_beta)

--- a/.azure-pipelines/cd-build-deploy-typescript-v1.yml
+++ b/.azure-pipelines/cd-build-deploy-typescript-v1.yml
@@ -53,9 +53,13 @@ extends:
               displayName: 'Install Node.js'
               inputs:
                 version: '22.x'
-            - script: npm ci
+            - task: Npm@1
               displayName: 'Install npm dependencies'
-              workingDirectory: '$(Build.SourcesDirectory)/typescript/'
+              inputs:
+                command: 'ci'
+                workingDir: '$(Build.SourcesDirectory)/typescript'
+                customRegistry: 'useFeed'
+                customFeed: 'Graph Developer Experiences/GraphDeveloperExperiences_Public'
 
             # Build V1 TypeScript package
             - script: npm run build --workspace=$(package_dir_v1)


### PR DESCRIPTION
Routes .NET, npm and Python (pip/poetry) dependency restore through the authenticated `GraphDeveloperExperiences_Public` Azure Artifacts feed (network isolation / CFS compliance). Needs a pipeline run to validate.