### PR TITLE
Use private feed for .NET pipeline restores

### DIFF
--- a/.azure-pipelines/cd-build-deploy-dotnet-beta.yml
+++ b/.azure-pipelines/cd-build-deploy-dotnet-beta.yml
@@ -70,7 +70,7 @@ extends:
                     <add key="GraphDeveloperExperiences_Public" value="https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/nuget/v3/index.json" />
                   </packageSources>
                 </configuration>
-                "@ | Set-Content -Path "$(Build.SourcesDirectory)/nuget.config" -Encoding UTF8
+                "@ | Set-Content -Path "$(Build.SourcesDirectory)/dotnet/nuget.config" -Encoding UTF8
               displayName: 'Create nuget.config (central feed)'
 
             # Enable signing for the .NET projects

--- a/.azure-pipelines/cd-build-deploy-dotnet-core.yml
+++ b/.azure-pipelines/cd-build-deploy-dotnet-core.yml
@@ -70,7 +70,7 @@ extends:
                     <add key="GraphDeveloperExperiences_Public" value="https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/nuget/v3/index.json" />
                   </packageSources>
                 </configuration>
-                "@ | Set-Content -Path "$(Build.SourcesDirectory)/nuget.config" -Encoding UTF8
+                "@ | Set-Content -Path "$(Build.SourcesDirectory)/dotnet/nuget.config" -Encoding UTF8
               displayName: 'Create nuget.config (central feed)'
 
             # Enable signing for the .NET projects

--- a/.azure-pipelines/cd-build-deploy-dotnet-v1.yml
+++ b/.azure-pipelines/cd-build-deploy-dotnet-v1.yml
@@ -73,7 +73,7 @@ extends:
                     <add key="GraphDeveloperExperiences_Public" value="https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/nuget/v3/index.json" />
                   </packageSources>
                 </configuration>
-                "@ | Set-Content -Path "$(Build.SourcesDirectory)/nuget.config" -Encoding UTF8
+                "@ | Set-Content -Path "$(Build.SourcesDirectory)/dotnet/nuget.config" -Encoding UTF8
               displayName: 'Create nuget.config (central feed)'
 
             # Enable signing for the .NET projects


### PR DESCRIPTION
## Summary

- write the pipeline-generated NuGet configuration into the `dotnet` directory
- replace the nearer checked-in `dotnet/nuget.config` that otherwise routes implicit restores to `api.nuget.org`
- apply the fix consistently to the v1, core, and beta .NET release pipelines

## Context

`dotnet` config discovery selected `dotnet/nuget.config` over the generated repository-root configuration. As a result, `DotNetCoreCLI` restore operations contacted `api.nuget.org` directly and violated the CFSClean network-isolation policy.