### PR TITLE
Fix .NET CFSClean leaks: drop legacy PackageValidation SDK (Core) + split restore/build/test (Core/Beta/V1)

### DIFF
--- a/.azure-pipelines/cd-build-deploy-dotnet-beta.yml
+++ b/.azure-pipelines/cd-build-deploy-dotnet-beta.yml
@@ -16,6 +16,10 @@ variables:
   buildConfiguration: 'Release'
   buildPlatform: 'Any CPU'
   nugetArtifacts: '$(Build.ArtifactStagingDirectory)/Nugets'
+  # Prevent the .NET SDK from downloading workload advertising manifests from nuget.org at
+  # build/restore startup (these projects use no workloads). This egress bypasses the CFS
+  # nuget.config and breaks CFSClean network isolation.
+  DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE: 'true'
 
 resources:
   repositories:

--- a/.azure-pipelines/cd-build-deploy-dotnet-beta.yml
+++ b/.azure-pipelines/cd-build-deploy-dotnet-beta.yml
@@ -96,14 +96,32 @@ extends:
 
               displayName: 'Set project build properties ready to sign'
 
-            # Build and test Beta
+            # Build and test Beta. Restore is a separate step (CFS central-feed nuget.config) so
+            # build/test run with --no-restore and perform no package resolution of their own,
+            # keeping all NuGet egress on the CFS feed (CFSClean).
+            - task: DotNetCoreCLI@2
+              displayName: 'Restore Microsoft.Agents.M365Copilot.Beta'
+              condition: or(contains(variables['Build.SourceBranch'], 'Microsoft.Agents.M365Copilot.Beta'), eq(variables['Build.Reason'], 'Manual'))
+              inputs:
+                command: restore
+                projects: '$(Build.SourcesDirectory)/dotnet/src/Microsoft.Agents.M365Copilot.Beta/Microsoft.Agents.M365Copilot.Beta.csproj'
+                feedsToUse: config
+                nugetConfigPath: '$(Build.SourcesDirectory)/dotnet/nuget.config'
             - task: DotNetCoreCLI@2
               displayName: 'Build Microsoft.Agents.M365Copilot.Beta'
               # This condition allows the build to run for both tag builds and manual builds.
               condition: or(contains(variables['Build.SourceBranch'], 'Microsoft.Agents.M365Copilot.Beta'), eq(variables['Build.Reason'], 'Manual'))
               inputs:
                 projects: '$(Build.SourcesDirectory)/dotnet/src/Microsoft.Agents.M365Copilot.Beta/Microsoft.Agents.M365Copilot.Beta.csproj'
-                arguments: '--configuration $(buildConfiguration) --no-incremental'
+                arguments: '--configuration $(buildConfiguration) --no-incremental --no-restore'
+            - task: DotNetCoreCLI@2
+              displayName: 'Restore Microsoft.Agents.M365Copilot.Beta.Tests'
+              condition: or(contains(variables['Build.SourceBranch'], 'Microsoft.Agents.M365Copilot.Beta'), eq(variables['Build.Reason'], 'Manual'))
+              inputs:
+                command: restore
+                projects: '$(Build.SourcesDirectory)/dotnet/tests/Microsoft.Agents.M365Copilot.Beta.Tests/Microsoft.Agents.M365Copilot.Beta.Tests.csproj'
+                feedsToUse: config
+                nugetConfigPath: '$(Build.SourcesDirectory)/dotnet/nuget.config'
             - task: DotNetCoreCLI@2
               displayName: 'Test Microsoft.Agents.M365Copilot.Beta'
               # This condition allows the build to run for both tag builds and manual builds.
@@ -111,7 +129,7 @@ extends:
               inputs:
                 command: test
                 projects: '$(Build.SourcesDirectory)/dotnet/tests/Microsoft.Agents.M365Copilot.Beta.Tests/Microsoft.Agents.M365Copilot.Beta.Tests.csproj'
-                arguments: '--configuration $(buildConfiguration)'
+                arguments: '--configuration $(buildConfiguration) --no-restore'
 
             # Strong name for Beta using ESRP
             - template: .azure-pipelines/templates/esrp-strongname.yml@self

--- a/.azure-pipelines/cd-build-deploy-dotnet-core.yml
+++ b/.azure-pipelines/cd-build-deploy-dotnet-core.yml
@@ -97,17 +97,32 @@ extends:
               displayName: 'Set project build properties ready to sign'
 
 
-            # Build and test Core
+            # Build and test Core. Restore is a separate step (using the CFS central-feed
+            # nuget.config) so the build/test steps run with --no-restore and perform no package
+            # resolution of their own - keeping all NuGet egress on the CFS feed (CFSClean).
+            - task: DotNetCoreCLI@2
+              displayName: 'Restore Microsoft.Agents.M365Copilot.Core'
+              condition: or(contains(variables['Build.SourceBranch'], 'Microsoft.Agents.M365Copilot.Core'), eq(variables['Build.Reason'], 'Manual'))
+              inputs:
+                command: restore
+                projects: '$(Build.SourcesDirectory)/dotnet/src/Microsoft.Agents.M365Copilot.Core/Microsoft.Agents.M365Copilot.Core.csproj'
+                feedsToUse: config
+                nugetConfigPath: '$(Build.SourcesDirectory)/dotnet/nuget.config'
             - task: DotNetCoreCLI@2
               displayName: 'Build Microsoft.Agents.M365Copilot.Core'
               # This condition allows the build to run for both tag builds and manual builds.
               condition: or(contains(variables['Build.SourceBranch'], 'Microsoft.Agents.M365Copilot.Core'), eq(variables['Build.Reason'], 'Manual'))
               inputs:
                 projects: '$(Build.SourcesDirectory)/dotnet/src/Microsoft.Agents.M365Copilot.Core/Microsoft.Agents.M365Copilot.Core.csproj'
-                # Force the implicit restore to use the CFS central-feed nuget.config (created
-                # above) rather than relying on directory walk-up, which still reached nuget.org
-                # and broke CFSClean network isolation.
-                arguments: '--configuration $(buildConfiguration) --no-incremental -p:RestoreConfigFile="$(Build.SourcesDirectory)/dotnet/nuget.config"'
+                arguments: '--configuration $(buildConfiguration) --no-incremental --no-restore'
+            - task: DotNetCoreCLI@2
+              displayName: 'Restore Microsoft.Agents.M365Copilot.Core.Tests'
+              condition: or(contains(variables['Build.SourceBranch'], 'Microsoft.Agents.M365Copilot.Core'), eq(variables['Build.Reason'], 'Manual'))
+              inputs:
+                command: restore
+                projects: '$(Build.SourcesDirectory)/dotnet/tests/Microsoft.Agents.M365Copilot.Core.Tests/Microsoft.Agents.M365Copilot.Core.Tests.csproj'
+                feedsToUse: config
+                nugetConfigPath: '$(Build.SourcesDirectory)/dotnet/nuget.config'
             - task: DotNetCoreCLI@2
               displayName: 'Test Microsoft.Agents.M365Copilot.Core'
               # This condition allows the build to run for both tag builds and manual builds.
@@ -115,7 +130,7 @@ extends:
               inputs:
                 command: test
                 projects: '$(Build.SourcesDirectory)/dotnet/tests/Microsoft.Agents.M365Copilot.Core.Tests/Microsoft.Agents.M365Copilot.Core.Tests.csproj'
-                arguments: '--configuration $(buildConfiguration) -p:RestoreConfigFile="$(Build.SourcesDirectory)/dotnet/nuget.config"'
+                arguments: '--configuration $(buildConfiguration) --no-restore'
 
             # Strong name for Core using ESRP
             - template: .azure-pipelines/templates/esrp-strongname.yml@self

--- a/.azure-pipelines/cd-build-deploy-dotnet-core.yml
+++ b/.azure-pipelines/cd-build-deploy-dotnet-core.yml
@@ -16,6 +16,10 @@ variables:
   buildConfiguration: 'Release'
   buildPlatform: 'Any CPU'
   nugetArtifacts: '$(Build.ArtifactStagingDirectory)/Nugets'
+  # Prevent the .NET SDK from downloading workload advertising manifests from nuget.org at
+  # build/restore startup (these projects use no workloads). This egress bypasses the CFS
+  # nuget.config and breaks CFSClean network isolation.
+  DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE: 'true'
 
 resources:
   repositories:

--- a/.azure-pipelines/cd-build-deploy-dotnet-v1.yml
+++ b/.azure-pipelines/cd-build-deploy-dotnet-v1.yml
@@ -99,14 +99,24 @@ extends:
 
               displayName: 'Set project build properties ready to sign'
 
-            # Build v1
+            # Build v1. Restore is a separate step (CFS central-feed nuget.config) so the build
+            # runs with --no-restore and performs no package resolution of its own, keeping all
+            # NuGet egress on the CFS feed (CFSClean).
+            - task: DotNetCoreCLI@2
+              displayName: 'Restore Microsoft.Agents.M365Copilot'
+              condition: or(contains(variables['Build.SourceBranch'], 'Microsoft.Agents.M365Copilot-'), eq(variables['Build.Reason'], 'Manual'))
+              inputs:
+                command: restore
+                projects: '$(Build.SourcesDirectory)/dotnet/src/Microsoft.Agents.M365Copilot/Microsoft.Agents.M365Copilot.csproj'
+                feedsToUse: config
+                nugetConfigPath: '$(Build.SourcesDirectory)/dotnet/nuget.config'
             - task: DotNetCoreCLI@2
               displayName: 'Build Microsoft.Agents.M365Copilot'
               # This condition allows the build to run for both tag builds and manual builds.
               condition: or(contains(variables['Build.SourceBranch'], 'Microsoft.Agents.M365Copilot-'), eq(variables['Build.Reason'], 'Manual'))
               inputs:
                 projects: '$(Build.SourcesDirectory)/dotnet/src/Microsoft.Agents.M365Copilot/Microsoft.Agents.M365Copilot.csproj'
-                arguments: '--configuration $(buildConfiguration) --no-incremental'
+                arguments: '--configuration $(buildConfiguration) --no-incremental --no-restore'
 
 
             # Strong name for v1 using ESRP

--- a/.azure-pipelines/cd-build-deploy-dotnet-v1.yml
+++ b/.azure-pipelines/cd-build-deploy-dotnet-v1.yml
@@ -19,6 +19,10 @@ variables:
   buildConfiguration: 'Release'
   buildPlatform: 'Any CPU'
   nugetArtifacts: '$(Build.ArtifactStagingDirectory)/Nugets'
+  # Prevent the .NET SDK from downloading workload advertising manifests from nuget.org at
+  # build/restore startup (these projects use no workloads). This egress bypasses the CFS
+  # nuget.config and breaks CFSClean network isolation.
+  DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE: 'true'
 
 resources:
   repositories:

--- a/dotnet/src/Microsoft.Agents.M365Copilot.Core/Microsoft.Agents.M365Copilot.Core.csproj
+++ b/dotnet/src/Microsoft.Agents.M365Copilot.Core/Microsoft.Agents.M365Copilot.Core.csproj
@@ -1,6 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
   <PropertyGroup>
+    <!-- Package validation is built into the .NET SDK (>= 6). The standalone
+         Microsoft.DotNet.PackageValidation MSBuild SDK was removed because its resolution ran
+         during project evaluation and reached nuget.org, breaking CFSClean network isolation. -->
+    <EnablePackageValidation>true</EnablePackageValidation>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net10.0</TargetFrameworks>
     <Description>Microsoft Agents M365 Copilot Client Library implements core functionality used by Microsoft Copilot client libraries.</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>


### PR DESCRIPTION
## CFSClean: fix build-time nuget.org egress on the three .NET pipelines

Routes all build-time NuGet egress for the Core (642), Beta (643) and V1 (649) .NET pipelines onto the CFS central feed, fixing CFSClean (1ES network isolation) violations. Two independent leaks were found and fixed:

### 1. Legacy PackageValidation MSBuild SDK (Core only)
`Microsoft.Agents.M365Copilot.Core.csproj` declared `<Sdk Name="Microsoft.DotNet.PackageValidation" .../>`. That SDK is resolved by the MSBuild **SDK resolver during project evaluation**, before restore, reaching nuget.org (~16 queries) regardless of `nuget.config`/`RestoreConfigFile`. Replaced with the in-box `<EnablePackageValidation>true</EnablePackageValidation>`. Beta/V1 never declared this SDK, so no csproj change for them.

### 2. .NET SDK workload advertising-manifest update (Beta + V1, and Core defensively)
Beta/V1 build **Core as a ProjectReference**; their build jobs still showed 16 `api.nuget.org` hits **after** the SDK fix. Root-caused via a published MSBuild **binlog**: the hits fire at `dotnet build` **startup/evaluation** (before the first target), from `Microsoft.NET.Sdk.WorkloadMSBuildSdkResolver` — the SDK's **workload advertising-manifest update**, a CLI-level fetch (~15 workload manifest packages) that **bypasses `nuget.config`** and isn't emitted through MSBuild logging. Package validation and NuGetAudit were both experimentally ruled out first. These projects use no workloads, so it's disabled via the documented switch `DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE=true` (added to all three pipelines).

### Also: restore/build/test split
Restore is a separate step using the CFS central-feed `nuget.config` (`feedsToUse: config` + `nugetConfigPath`); build/test run with `--no-restore` so they perform no package resolution of their own.

### Validation
| Pipeline | Build+Sign stage | `api.nuget.org` in build job |
|---|---|---|
| Core 642 (before) | ✅ | 16 → **0** after SDK fix (build 231011) |
| Beta 643 | ✅ | 16 → **0** with workload var (build 231063) |
| V1 649 | ✅ | (same shared cause; covered by same fix) |

Final combined validation runs on this branch: 231073 (Core), 231074 (Beta), 231075 (V1).

> Note: the Deploy stage's "Publish … via NuGet API Key" step is an **intended external publish** to nuget.org and still shows 2 hits — that requires a CFSClean **exception**, not a code change.
