### PR TITLE
Make Python CD pipelines CFSClean-compliant (Core/Beta/V1) + fix poetry feed auth

### DIFF
--- a/.azure-pipelines/cd-build-deploy-python-beta.yml
+++ b/.azure-pipelines/cd-build-deploy-python-beta.yml
@@ -66,17 +66,21 @@ extends:
 
             - script: |
                 poetry source add --priority=primary azure-feed "https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/pypi/simple/"
-                poetry config http-basic.azure-feed "azure" "$SYSTEM_ACCESSTOKEN"
               displayName: 'Configure Poetry to use Azure Artifacts feed'
               workingDirectory: '$(Build.SourcesDirectory)/python/$(library_dir_beta)'
               condition: or(contains(variables['Build.SourceBranch'], 'microsoft_agents_m365copilot_beta'), eq(variables['Build.Reason'], 'Manual'))
-              env:
-                SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
             - script: poetry install
               displayName: 'Install beta dependencies'
               workingDirectory: '$(Build.SourcesDirectory)/python/$(library_dir_beta)'
               condition: or(contains(variables['Build.SourceBranch'], 'microsoft_agents_m365copilot_beta'), eq(variables['Build.Reason'], 'Manual'))
+              # Authenticate poetry to the Azure Artifacts feed via env vars (shell/OS-agnostic).
+              # The previous `poetry config http-basic ... "$SYSTEM_ACCESSTOKEN"` step failed on
+              # Windows/cmd agents because cmd.exe does not expand the bash-style $VAR, so poetry
+              # stored the literal string as the password and every feed request returned 401.
+              env:
+                POETRY_HTTP_BASIC_AZURE_FEED_USERNAME: azure
+                POETRY_HTTP_BASIC_AZURE_FEED_PASSWORD: $(System.AccessToken)
 
             - script: poetry run isort .
               displayName: 'Check import order'

--- a/.azure-pipelines/cd-build-deploy-python-beta.yml
+++ b/.azure-pipelines/cd-build-deploy-python-beta.yml
@@ -89,6 +89,11 @@ extends:
 
             - script: poetry build
               displayName: 'Build Python package'
+              # poetry build uses PEP 517 build isolation and resolves the [build-system] requires
+              # (setuptools/wheel/poetry-core) from the feed, so it needs the same feed credentials.
+              env:
+                POETRY_HTTP_BASIC_AZURE_FEED_USERNAME: azure
+                POETRY_HTTP_BASIC_AZURE_FEED_PASSWORD: $(System.AccessToken)
               condition: or(contains(variables['Build.SourceBranch'], 'microsoft_agents_m365copilot_beta'), eq(variables['Build.Reason'], 'Manual'))
               workingDirectory: '$(Build.SourcesDirectory)/python/$(library_dir_beta)'
               

--- a/.azure-pipelines/cd-build-deploy-python-core.yml
+++ b/.azure-pipelines/cd-build-deploy-python-core.yml
@@ -101,6 +101,11 @@ extends:
 
             - script: poetry build
               displayName: 'Build Python package'
+              # poetry build uses PEP 517 build isolation and resolves the [build-system] requires
+              # (setuptools/wheel/poetry-core) from the feed, so it needs the same feed credentials.
+              env:
+                POETRY_HTTP_BASIC_AZURE_FEED_USERNAME: azure
+                POETRY_HTTP_BASIC_AZURE_FEED_PASSWORD: $(System.AccessToken)
               condition: or(contains(variables['Build.SourceBranch'], 'microsoft_agents_m365copilot_core'), eq(variables['Build.Reason'], 'Manual'))
               workingDirectory: '$(Build.SourcesDirectory)/python/$(library_dir_core)'     
               

--- a/.azure-pipelines/cd-build-deploy-python-core.yml
+++ b/.azure-pipelines/cd-build-deploy-python-core.yml
@@ -49,6 +49,12 @@ extends:
                 versionSpec: '3.x'
                 addToPath: true
 
+            - task: PipAuthenticate@1
+              displayName: 'Authenticate pip to Azure Artifacts'
+              inputs:
+                artifactFeeds: '$(System.TeamProject)/GraphDeveloperExperiences_Public'
+                onlyAddExtraIndex: false
+
             - script: python -m pip install --upgrade pip
 
             # Build, test, and package Core Python library
@@ -58,10 +64,20 @@ extends:
               # This condition allows the build to run for both tagged core builds or manual builds.
               condition: or(contains(variables['Build.SourceBranch'], 'microsoft_agents_m365copilot_core'), eq(variables['Build.Reason'], 'Manual'))    
               
+            - script: |
+                poetry source add --priority=primary azure-feed "https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/pypi/simple/"
+              displayName: 'Configure Poetry to use Azure Artifacts feed'
+              workingDirectory: '$(Build.SourcesDirectory)/python/$(library_dir_core)'
+              condition: or(contains(variables['Build.SourceBranch'], 'microsoft_agents_m365copilot_core'), eq(variables['Build.Reason'], 'Manual'))
+
             - script: poetry install
               displayName: 'Install core dependencies'
               workingDirectory: '$(Build.SourcesDirectory)/python/$(library_dir_core)'
               condition: or(contains(variables['Build.SourceBranch'], 'microsoft_agents_m365copilot_core'), eq(variables['Build.Reason'], 'Manual'))
+              # Authenticate poetry to the Azure Artifacts feed via env vars (shell/OS-agnostic).
+              env:
+                POETRY_HTTP_BASIC_AZURE_FEED_USERNAME: azure
+                POETRY_HTTP_BASIC_AZURE_FEED_PASSWORD: $(System.AccessToken)
 
             - script: poetry run yapf -dr .
               displayName: 'Check code format for core' # Core only

--- a/.azure-pipelines/cd-build-deploy-python-v1.yml
+++ b/.azure-pipelines/cd-build-deploy-python-v1.yml
@@ -100,6 +100,11 @@ extends:
 
             - script: poetry build
               displayName: 'Build Python package'
+              # poetry build uses PEP 517 build isolation and resolves the [build-system] requires
+              # (setuptools/wheel/poetry-core) from the feed, so it needs the same feed credentials.
+              env:
+                POETRY_HTTP_BASIC_AZURE_FEED_USERNAME: azure
+                POETRY_HTTP_BASIC_AZURE_FEED_PASSWORD: $(System.AccessToken)
               workingDirectory: '$(Build.SourcesDirectory)/python/$(library_dir_v1)'
               
             - task: CopyFiles@2

--- a/.azure-pipelines/cd-build-deploy-python-v1.yml
+++ b/.azure-pipelines/cd-build-deploy-python-v1.yml
@@ -80,15 +80,19 @@ extends:
 
             - script: |
                 poetry source add --priority=primary azure-feed "https://microsoftgraph.pkgs.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_packaging/GraphDeveloperExperiences_Public/pypi/simple/"
-                poetry config http-basic.azure-feed "azure" "$SYSTEM_ACCESSTOKEN"
               displayName: 'Configure Poetry to use Azure Artifacts feed'
               workingDirectory: '$(Build.SourcesDirectory)/python/$(library_dir_v1)'
-              env:
-                SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
             - script: poetry install
               displayName: 'Install v1 dependencies'
               workingDirectory: '$(Build.SourcesDirectory)/python/$(library_dir_v1)'
+              # Authenticate poetry to the Azure Artifacts feed via env vars (shell/OS-agnostic).
+              # The previous `poetry config http-basic ... "$SYSTEM_ACCESSTOKEN"` step failed on
+              # Windows/cmd agents because cmd.exe does not expand the bash-style $VAR, so poetry
+              # stored the literal string as the password and every feed request returned 401.
+              env:
+                POETRY_HTTP_BASIC_AZURE_FEED_USERNAME: azure
+                POETRY_HTTP_BASIC_AZURE_FEED_PASSWORD: $(System.AccessToken)
 
             - script: poetry run isort .
               displayName: 'Check import order'


### PR DESCRIPTION
## Make the Python CD pipelines CFSClean-compliant (Core / Beta / V1)

Routes all package installs in the Python **Core**, **Beta (639)**, and **V1** CD pipelines through the CFS private feed (`GraphDeveloperExperiences_Public`), and fixes the feed-auth bug that was failing the Beta/V1 release builds.

### Beta & V1 — fix broken feed auth
The `Configure Poetry` step used `poetry config http-basic.azure-feed "azure" "$SYSTEM_ACCESSTOKEN"` in a `- script:` step. On the **Windows/cmd release agents** cmd.exe does not expand the bash-style `$SYSTEM_ACCESSTOKEN`, so poetry stored the **literal string** as the feed password → every request to the feed returned an Authorization error and `poetry install` failed (surfaced misleadingly as "version solving failed"). Confirmed from build **230796** (log shows `cmd.exe`). `PipAuthenticate` to the same feed already succeeds, so the build identity has read access — purely a token-passing bug.

Replaced the shell-expanded config with poetry's native, shell/OS-agnostic **env-var credentials** on the install step:
```yaml
env:
  POETRY_HTTP_BASIC_AZURE_FEED_USERNAME: azure
  POETRY_HTTP_BASIC_AZURE_FEED_PASSWORD: $(System.AccessToken)
```

### Core — add CFSClean routing (was missing entirely)
Python Core had **no** private-feed configuration: `pip install poetry` and `poetry install` pulled straight from public PyPI — a CFSClean violation. Brought Core to parity with Beta/V1:
- **PipAuthenticate@1** (`onlyAddExtraIndex: false`) → pip installs resolve from the CFS feed, not pypi.org.
- **`poetry source add --priority=primary azure-feed <CFS>`** → since no PyPI source is declared in `pyproject.toml`, poetry disables the implicit PyPI source and resolves everything through the CFS feed (which upstreams PyPI).
- **`POETRY_HTTP_BASIC_AZURE_FEED_*`** env-var auth on the install step.

### Why this is CFSClean-correct
With `priority=primary` and **no** `[[tool.poetry.source]]` PyPI entry in any package's `pyproject.toml`, poetry does **not** fall back to pypi.org — all resolution goes through the CFS feed. `PipAuthenticate` covers the separate `pip install poetry`/`pip upgrade` path.

### Validation
After merge, queue manual runs of the Core, Beta, and V1 Python pipelines and confirm: build stage succeeds, and CFSClean telemetry shows no `pypi.org` / `files.pythonhosted.org` egress.
